### PR TITLE
🐛eslint와 prettier의 줄바꿈 형식 에러 해결

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,6 @@
   "semi": false,
   "singleQuote": true,
   "jsxSingleQuote": true,
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "endOfLine": "lf"
 }


### PR DESCRIPTION
## 💡 배경 및 개요

새로운 파일이나 git pull, clone을 받으면 줄바꿈 에러가 생기는 이슈가 있었다.

## 📃 작업내용

prettier에 lf형식으로 절대적으로 지정
