### PR TITLE
🔥주말 건너뛰기 기능 삭제

### DIFF
--- a/src/components/DateButton/index.tsx
+++ b/src/components/DateButton/index.tsx
@@ -9,10 +9,9 @@ interface DateProps {
 
 const DateButton: React.FC<DateProps> = ({ setCurrentDate }) => {
   const [selectedButton, setSelectedButton] = useState(0)
-  const [weekendSkip, setWeekendSkip] = useState(false)
   const [mealToggle, setMealToggle] = useState(false)
 
-  useGetAllSetting(setMealToggle, setWeekendSkip)
+  useGetAllSetting(setMealToggle)
 
   useEffect(() => {
     const currentDate = new Date()
@@ -31,24 +30,6 @@ const DateButton: React.FC<DateProps> = ({ setCurrentDate }) => {
     }
   }, [mealToggle, setCurrentDate])
 
-  // useEffect(() => {
-  //   let today = new Date()
-  //   if (weekendSkip) {
-  //     today = adjustDate(today)
-  //   }
-  //   setCurrentDate(today)
-  // }, [weekendSkip, setCurrentDate])
-
-  // const adjustDate = (date: Date) => {
-  //   const day = date.getDay()
-  //   if (day === 0) {
-  //     date.setDate(date.getDate() + 1)
-  //   } else if (day === 6) {
-  //     date.setDate(date.getDate() + 2)
-  //   }
-  //   return date
-  // }
-
   const handleDateButtonClick = (days: number) => {
     if (selectedButton === days) {
       return
@@ -56,15 +37,6 @@ const DateButton: React.FC<DateProps> = ({ setCurrentDate }) => {
 
     const today = new Date()
     today.setDate(today.getDate() + days)
-    if (weekendSkip) {
-      if (days === 0) {
-        // today = adjustDate(today)
-      } else if (days === 1 && today.getDay() === 6) {
-        // today.setDate(today.getDate() + 2)
-      } else if (days === -1 && today.getDay() === 0) {
-        // today.setDate(today.getDate() - 2)
-      }
-    }
 
     setCurrentDate(today)
     setSelectedButton(days)

--- a/src/hook/profile/useGetSetting.ts
+++ b/src/hook/profile/useGetSetting.ts
@@ -2,7 +2,6 @@ import { useEffect } from 'react'
 
 export function useGetAllSetting(
   setMealToggle?: React.Dispatch<React.SetStateAction<boolean>>,
-  setWeekendSkip?: React.Dispatch<React.SetStateAction<boolean>>,
 ) {
   useEffect(() => {
     const updateState = (
@@ -26,6 +25,6 @@ export function useGetAllSetting(
     }
 
     updateState('mealToggle', setMealToggle)
-    updateState('weekendSkip', setWeekendSkip)
-  }, [setMealToggle, setWeekendSkip])
+    updateState('weekendSkip')
+  }, [setMealToggle])
 }

--- a/src/page/setting/index.tsx
+++ b/src/page/setting/index.tsx
@@ -5,7 +5,7 @@ import Logo from '@stories/atoms/Logo'
 import MyProfile from '@stories/atoms/MyProfile'
 import Return from '@stories/atoms/Return'
 import ToggleSwitch from '@stories/atoms/ToggleSwitch'
-import { Allergies, Calendar, Feedback, Rice } from '@stories/icons/index'
+import { Allergies, Feedback, Rice } from '@stories/icons/index'
 import SettingList from '@stories/molecules/SettingList'
 import { useState } from 'react'
 import { useCookies } from 'react-cookie'
@@ -15,9 +15,8 @@ const Setting = () => {
   const [cookies] = useCookies(['SCHUL_NM', 'USER_GRADE', 'USER_CLASS'])
   const { SCHUL_NM = '', USER_GRADE = '', USER_CLASS = '' } = cookies
   const [mealToggle, setMealToggle] = useState<boolean>(false)
-  const [weekendSkip, setWeekendSkip] = useState<boolean>(false)
 
-  useGetAllSetting(setMealToggle, setWeekendSkip)
+  useGetAllSetting(setMealToggle)
 
   return (
     <S.Wrapper>
@@ -49,17 +48,6 @@ const Setting = () => {
               isActive={mealToggle}
               setIsActive={setMealToggle}
               settingKey='mealToggle'
-            />
-          }
-        />
-        <SettingList
-          icons={<Calendar />}
-          text='주말 건너뛰기'
-          components={
-            <ToggleSwitch
-              isActive={weekendSkip}
-              setIsActive={setWeekendSkip}
-              settingKey='weekendSkip'
             />
           }
         />


### PR DESCRIPTION
## 💡 배경 및 개요

주말 건너뛰기 기능 삭제




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **기능 제거**
	- 주말 건너뛰기 설정 기능 완전 삭제
	- 관련된 상태 관리 및 토글 스위치 제거
	- 날짜 조정 로직 단순화

- **후크 변경**
	- `useGetAllSetting` 후크에서 주말 건너뛰기 관련 매개변수 제거

- **컴포넌트 업데이트**
	- 설정 페이지에서 주말 건너뛰기 옵션 제거
	- 불필요한 상태 및 아이콘 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->