### PR TITLE
🐛Fix:tanstack query key 이슈 해결

### DIFF
--- a/src/hook/date/useFormattedDate.ts
+++ b/src/hook/date/useFormattedDate.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react'
+
+const useFormattedDate = (date: Date) => {
+  const formattedDate = useMemo(() => {
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
+  }, [date])
+
+  return formattedDate
+}
+
+export default useFormattedDate

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,10 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import ReactDOM from 'react-dom/client'
+import TanstackProviders from '@util/lib/TanstackProviders'
 import App from './App'
-
-const queryClient = new QueryClient()
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
-  <QueryClientProvider client={queryClient}>
+  <TanstackProviders>
     <App />
-  </QueryClientProvider>,
+  </TanstackProviders>,
 )

--- a/src/page/meal/index.tsx
+++ b/src/page/meal/index.tsx
@@ -1,6 +1,7 @@
 import DateButton from '@components/DateButton'
 import FilterMealList from '@components/FilterMealList'
 import MealButton from '@components/MealButton'
+import useFormattedDate from '@hook/date/useFormattedDate'
 import { useGetAllergy } from '@hook/profile/useGetAllergy'
 import { Rice } from '@stories/assets/svg'
 import Logo from '@stories/atoms/Logo'
@@ -22,10 +23,8 @@ const Meal = () => {
   useGetAllergy(setSelectedAllergies)
 
   const { data, isLoading } = useQuery<MealResponse>({
-    queryKey: ['mealData', currentDate],
+    queryKey: ['mealData', useFormattedDate(currentDate)],
     queryFn: () => getMeal(cookies, currentDate),
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
   })
 
   const mealData: ProcessedMealData = useMemo(() => {

--- a/src/page/schedule/index.tsx
+++ b/src/page/schedule/index.tsx
@@ -1,5 +1,6 @@
 import DateButton from '@components/DateButton'
 import useScheduleCookie from '@hook/cookie/useScheduleCookie'
+import useFormattedDate from '@hook/date/useFormattedDate'
 import { Stroke } from '@stories/assets/svg'
 import Logo from '@stories/atoms/Logo'
 import Return from '@stories/atoms/Return'
@@ -27,7 +28,7 @@ const Schedule = () => {
   const scheduleURL = getScheduleURL(SCHUL_KND_SC_NM)
 
   const { data, isLoading } = useQuery<ScheduleData[]>({
-    queryKey: ['scheduleData', currentDate],
+    queryKey: ['scheduleData', useFormattedDate(currentDate)],
     queryFn: () =>
       getSchedule(
         ATPT_OFCDC_SC_CODE,
@@ -38,8 +39,6 @@ const Schedule = () => {
         scheduleURL,
         currentDate,
       ),
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
   })
 
   return (

--- a/src/util/lib/TanstackProviders.tsx
+++ b/src/util/lib/TanstackProviders.tsx
@@ -1,0 +1,24 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
+
+const TanstackProviders = ({ children }: { children: React.ReactNode }) => {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+            gcTime: 60 * 5000,
+            retryDelay: 1500,
+            retry: 5,
+          },
+        },
+      }),
+  )
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+export default TanstackProviders


### PR DESCRIPTION
## 💡 배경 및 개요
tanstack query의 캐싱이 제대로 적용되지 않은 이슈가 발생했다.


## 📃 작업내용

기존의 tanstack query의 키는 고유키와 상황에 따라 바뀌는 date키 2개로 되어있었다. 하지만 date의 값이 날짜만이 아닌 시간까지 포함되고 있었다. 그렇기에 staleTime이 지나지 않았음에도 캐싱이 되지 않고 있었다.

