### PR TITLE
🐛Fix: 쿠키 만료일 이슈 해결

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.0.8",
+  "version": "1.0.9",
   "short_name": "React App",
   "name": "오늘 뭐임",
   "action": {

--- a/src/util/expirationCookie.ts
+++ b/src/util/expirationCookie.ts
@@ -1,5 +1,12 @@
 export const expirationCookie = (): Date => {
   const now: Date = new Date()
-  const expirationDate: Date = new Date(now.getFullYear(), 2, 1, 23, 59, 59)
+  let expirationDate: Date
+
+  if (now.getMonth() < 2 || (now.getMonth() === 2 && now.getDate() === 1)) {
+    expirationDate = new Date(now.getFullYear(), 2, 1)
+  } else {
+    expirationDate = new Date(now.getFullYear() + 1, 2, 1)
+  }
+
   return expirationDate
 }


### PR DESCRIPTION
## 💡 배경 및 개요
기존에 만료일을 1월 1일에서 3월 1일로 변경 했더니 3월 1일 이후의 날짜는 쿠키가 삭제되어 버리는 문제가 발생했다.

## 📃 작업내용
- 쿠키 만료일을 해당 년도 이전과 이후로 검증을 진행해 상황에 따라 만료되게 설정하였다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 애플리케이션 버전이 1.0.8에서 1.0.9로 업데이트되었습니다.
  
- **Refactor**
  - 사용자 세션 만료 날짜 계산 로직을 개선하여 현재 날짜에 따라 보다 적절하게 만료 시점이 설정되도록 변경하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->